### PR TITLE
Merge branch release/1.0.1 into develop

### DIFF
--- a/.changes/v1.0.1.md
+++ b/.changes/v1.0.1.md
@@ -1,0 +1,145 @@
+## v1.0.1 (2025-09-08)
+
+### Bug Fixes
+
+- update typescript configs
+
+- address minor issues
+
+- page /projects
+
+- component name
+
+- wrong script name
+
+- update translations
+
+- add empty template to avoid warning
+
+- correct footer code
+
+- typescript warnings
+
+- export types
+
+- typescript reports
+
+- **composable:** sort object properties by count value
+
+- **demo:** update demo config
+
+- **demo:** add footer config
+
+- **deployment:** update build environment variables
+
+- **deps:** update dependency vue-i18n to v11.1.10 ([#200](https://github.com/ansidev/vitepress-theme-ansidev/issues/200))
+
+- **deps:** update dependency vue-i18n to v11.1.9 ([#190](https://github.com/ansidev/vitepress-theme-ansidev/issues/190))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.4.0 ([#173](https://github.com/ansidev/vitepress-theme-ansidev/issues/173))
+
+- **deps:** update dependency vue-i18n to v11.1.6 ([#159](https://github.com/ansidev/vitepress-theme-ansidev/issues/159))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.3.0 ([#157](https://github.com/ansidev/vitepress-theme-ansidev/issues/157))
+
+- **deps:** update dependency vue-i18n to v11.1.4
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.2.0
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.1.0 ([#122](https://github.com/ansidev/vitepress-theme-ansidev/issues/122))
+
+- **deps:** update dependency vue-i18n to v11.1.3 ([#120](https://github.com/ansidev/vitepress-theme-ansidev/issues/120))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13
+
+- **deps:** update dependency vue-i18n to v11.1.2 ([#91](https://github.com/ansidev/vitepress-theme-ansidev/issues/91))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v12.8.2
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v12.7.0 ([#64](https://github.com/ansidev/vitepress-theme-ansidev/issues/64))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v12.6.1 ([#63](https://github.com/ansidev/vitepress-theme-ansidev/issues/63))
+
+- **deps:** update dependency vue-i18n to v11.1.1
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.5.0 ([#187](https://github.com/ansidev/vitepress-theme-ansidev/issues/187))
+
+- **deps:** update dependency vue-i18n to v11.1.8 ([#189](https://github.com/ansidev/vitepress-theme-ansidev/issues/189))
+
+- **deps:** update dependency vue-i18n to v11.1.7 ([#174](https://github.com/ansidev/vitepress-theme-ansidev/issues/174))
+
+- **deps:** update dependency vue-i18n to v11
+
+- **deps:** update dependency vue-i18n to v11.1.11 ([#206](https://github.com/ansidev/vitepress-theme-ansidev/issues/206))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.6.0 ([#209](https://github.com/ansidev/vitepress-theme-ansidev/issues/209))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.7.0 ([#221](https://github.com/ansidev/vitepress-theme-ansidev/issues/221))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.8.0 ([#228](https://github.com/ansidev/vitepress-theme-ansidev/issues/228))
+
+- **deps:** update dependency vue-i18n to v11
+
+- **deps:** update dependency vue-i18n to v11.1.12 ([#234](https://github.com/ansidev/vitepress-theme-ansidev/issues/234))
+
+- **deps:** update dependency vue-i18n to v11.1.0 ([#37](https://github.com/ansidev/vitepress-theme-ansidev/issues/37))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.9.0 ([#235](https://github.com/ansidev/vitepress-theme-ansidev/issues/235))
+
+- **github-actions:** correct syntax
+
+- **github-actions:** do not suppress errors
+
+- **github-actions:** check whether PR branch exists before deletion
+
+- **github-actions:** skip PR branch deletion if the PR branch does not exist
+
+- **github-actions:** do not return exit code 1
+
+- **github-workflow:** correct deployment github action config
+
+- **site:** correct pnpm build script and output dir
+
+- **task:** update tasks
+
+### Code Refactoring
+
+- move component GoogleAnalytics to plugins directory
+
+- rename ProjectPage to ProjectsPage
+
+### Features
+
+- add component LocaleSwitcher
+
+- add custom footer
+
+- add github workflow to deploy to Netlify
+
+- filter projects by technology
+
+- enable local search plugin
+
+- use postcss plugin
+
+- add page /projects-by-tech/{tech}
+
+- **changelog:** add changelog config
+
+- **demo:** add demo config for donation plugin
+
+- **github-actions:** add workflow to publish NPM package
+
+- **github-actions:** add GitHub Actions workflows
+
+- **page:** add pages /archives and /archives/{year}
+
+- **plugin-donation:** add plugin Donation
+
+- **plugin-google-analytics:** add plugin Google Analytics
+
+- **renovate:** update renovate config
+
+- **taskfile:** add task files
+
+Full Changelog: [v1.0.1](https://github.com/ansidev/vitepress-theme-ansidev/commits/v1.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,152 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## v1.0.1 (2025-09-08)
+
+### Bug Fixes
+
+- update typescript configs
+
+- address minor issues
+
+- page /projects
+
+- component name
+
+- wrong script name
+
+- update translations
+
+- add empty template to avoid warning
+
+- correct footer code
+
+- typescript warnings
+
+- export types
+
+- typescript reports
+
+- **composable:** sort object properties by count value
+
+- **demo:** update demo config
+
+- **demo:** add footer config
+
+- **deployment:** update build environment variables
+
+- **deps:** update dependency vue-i18n to v11.1.10 ([#200](https://github.com/ansidev/vitepress-theme-ansidev/issues/200))
+
+- **deps:** update dependency vue-i18n to v11.1.9 ([#190](https://github.com/ansidev/vitepress-theme-ansidev/issues/190))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.4.0 ([#173](https://github.com/ansidev/vitepress-theme-ansidev/issues/173))
+
+- **deps:** update dependency vue-i18n to v11.1.6 ([#159](https://github.com/ansidev/vitepress-theme-ansidev/issues/159))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.3.0 ([#157](https://github.com/ansidev/vitepress-theme-ansidev/issues/157))
+
+- **deps:** update dependency vue-i18n to v11.1.4
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.2.0
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.1.0 ([#122](https://github.com/ansidev/vitepress-theme-ansidev/issues/122))
+
+- **deps:** update dependency vue-i18n to v11.1.3 ([#120](https://github.com/ansidev/vitepress-theme-ansidev/issues/120))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13
+
+- **deps:** update dependency vue-i18n to v11.1.2 ([#91](https://github.com/ansidev/vitepress-theme-ansidev/issues/91))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v12.8.2
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v12.7.0 ([#64](https://github.com/ansidev/vitepress-theme-ansidev/issues/64))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v12.6.1 ([#63](https://github.com/ansidev/vitepress-theme-ansidev/issues/63))
+
+- **deps:** update dependency vue-i18n to v11.1.1
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.5.0 ([#187](https://github.com/ansidev/vitepress-theme-ansidev/issues/187))
+
+- **deps:** update dependency vue-i18n to v11.1.8 ([#189](https://github.com/ansidev/vitepress-theme-ansidev/issues/189))
+
+- **deps:** update dependency vue-i18n to v11.1.7 ([#174](https://github.com/ansidev/vitepress-theme-ansidev/issues/174))
+
+- **deps:** update dependency vue-i18n to v11
+
+- **deps:** update dependency vue-i18n to v11.1.11 ([#206](https://github.com/ansidev/vitepress-theme-ansidev/issues/206))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.6.0 ([#209](https://github.com/ansidev/vitepress-theme-ansidev/issues/209))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.7.0 ([#221](https://github.com/ansidev/vitepress-theme-ansidev/issues/221))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.8.0 ([#228](https://github.com/ansidev/vitepress-theme-ansidev/issues/228))
+
+- **deps:** update dependency vue-i18n to v11
+
+- **deps:** update dependency vue-i18n to v11.1.12 ([#234](https://github.com/ansidev/vitepress-theme-ansidev/issues/234))
+
+- **deps:** update dependency vue-i18n to v11.1.0 ([#37](https://github.com/ansidev/vitepress-theme-ansidev/issues/37))
+
+- **deps:** update dependency [@vueuse](https://github.com/vueuse)/core to v13.9.0 ([#235](https://github.com/ansidev/vitepress-theme-ansidev/issues/235))
+
+- **github-actions:** correct syntax
+
+- **github-actions:** do not suppress errors
+
+- **github-actions:** check whether PR branch exists before deletion
+
+- **github-actions:** skip PR branch deletion if the PR branch does not exist
+
+- **github-actions:** do not return exit code 1
+
+- **github-workflow:** correct deployment github action config
+
+- **site:** correct pnpm build script and output dir
+
+- **task:** update tasks
+
+### Code Refactoring
+
+- move component GoogleAnalytics to plugins directory
+
+- rename ProjectPage to ProjectsPage
+
+### Features
+
+- add component LocaleSwitcher
+
+- add custom footer
+
+- add github workflow to deploy to Netlify
+
+- filter projects by technology
+
+- enable local search plugin
+
+- use postcss plugin
+
+- add page /projects-by-tech/{tech}
+
+- **changelog:** add changelog config
+
+- **demo:** add demo config for donation plugin
+
+- **github-actions:** add workflow to publish NPM package
+
+- **github-actions:** add GitHub Actions workflows
+
+- **page:** add pages /archives and /archives/{year}
+
+- **plugin-donation:** add plugin Donation
+
+- **plugin-google-analytics:** add plugin Google Analytics
+
+- **renovate:** update renovate config
+
+- **taskfile:** add task files
+
+Full Changelog: [v1.0.1](https://github.com/ansidev/vitepress-theme-ansidev/commits/v1.0.1)
+
 ## v1.0.0 (2025-09-08)
 
 ### Bug Fixes


### PR DESCRIPTION
This PR merges the branch `release/1.0.1` back into the branch `develop`.

This ensures that the updates on the branch `release/1.0.1`, i.e. CHANGELOG and manifest updates, are also present on the branch `develop`.